### PR TITLE
Default to empty result: Fixes Ahmednull/L2CS-Net#22

### DIFF
--- a/l2cs/pipeline.py
+++ b/l2cs/pipeline.py
@@ -55,6 +55,13 @@ class Pipeline:
         landmarks = []
         scores = []
 
+        # default stacks
+        pitch = np.empty((0,1))
+        yaw = np.empty((0,1))
+        bboxes_stack = np.empty((0,1))
+        landmarks_stack = np.empty((0,1))
+        scores_stack = np.empty((0,1))
+
         if self.include_detector:
             faces = self.detector(frame)
 
@@ -86,14 +93,12 @@ class Pipeline:
                     landmarks.append(landmark)
                     scores.append(score)
 
-                # Predict gaze
-                pitch, yaw = self.predict_gaze(np.stack(face_imgs))
-
-            else:
-
-                pitch = np.empty((0,1))
-                yaw = np.empty((0,1))
-
+                if len(face_imgs) > 0:
+                    # Predict gaze
+                    pitch, yaw = self.predict_gaze(np.stack(face_imgs))
+                    bboxes_stack = np.stack(bboxes)
+                    landmarks_stack = np.stack(landmarks)
+                    scores_stack = np.stack(scores)
         else:
             pitch, yaw = self.predict_gaze(frame)
 
@@ -101,9 +106,9 @@ class Pipeline:
         results = GazeResultContainer(
             pitch=pitch,
             yaw=yaw,
-            bboxes=np.stack(bboxes),
-            landmarks=np.stack(landmarks),
-            scores=np.stack(scores)
+            bboxes=bboxes_stack,
+            landmarks=landmarks_stack,
+            scores=scores_stack
         )
 
         return results


### PR DESCRIPTION
Implemented a fix for issue #22, where modern versions of numpy would ValueError when trying to process a frame without any detected faces. The fix simply defaults the return value of the pipeline to an empty numpy array when there are no faces detected, and continues with the current logic if there are faces detected.