### PR TITLE
Added handling of no detection and a mode for detecting only one face

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Install package with the following:
 ```
 pip install git+https://github.com/edavalosanaya/L2CS-Net.git@main
 ```
-Or this fork by changing the url accordingly.
 
 Or, you can git clone the repo and install with the following:
 
@@ -43,22 +42,26 @@ Detect face and predict gaze from webcam
 from l2cs import Pipeline, render
 import cv2
 import pathlib
-
+import torch
 
 CWD = pathlib.Path.cwd()
 
 gaze_pipeline = Pipeline(
     weights=CWD / 'models' / 'L2CSNet_gaze360.pkl',
     arch='ResNet50',
-    device=torch.device('cpu') # or 'gpu'
+    device=torch.device('cpu') # or 'cuda', 'opengl', ...
 )
  
-cap = cv2.VideoCapture(cam)
+cap = cv2.VideoCapture(0)
 _, frame = cap.read()    
 
 # Process frame and visualize
 results = gaze_pipeline.step(frame)
 frame = render(frame, results)
+
+cv2.imshow("Detected face", frame)
+cv2.waitKey(0)
+cv2.destroyAllWindows()
 ```
 
 ## Demo

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Install package with the following:
 ```
 pip install git+https://github.com/edavalosanaya/L2CS-Net.git@main
 ```
+Or this fork by changing the url accordingly.
 
 Or, you can git clone the repo and install with the following:
 
@@ -41,6 +42,10 @@ Detect face and predict gaze from webcam
 ```python
 from l2cs import Pipeline, render
 import cv2
+import pathlib
+
+
+CWD = pathlib.Path.cwd()
 
 gaze_pipeline = Pipeline(
     weights=CWD / 'models' / 'L2CSNet_gaze360.pkl',

--- a/l2cs/pipeline.py
+++ b/l2cs/pipeline.py
@@ -92,7 +92,6 @@ class Pipeline:
                 if single_face and len(face_imgs) > 1:
                     max_score_index = accepted_scores.index(max(accepted_scores))
                     face_imgs = [face_imgs[max_score_index]]
-                    print(f"More than one face detected, selected face with confidence {max(accepted_scores)} from options: {accepted_scores}")
 
                 # Predict gaze
                 if len(face_imgs) != 0:

--- a/l2cs/results.py
+++ b/l2cs/results.py
@@ -6,6 +6,7 @@ class GazeResultContainer:
 
     pitch: np.ndarray
     yaw: np.ndarray
-    bboxes: np.ndarray
-    landmarks: np.ndarray
-    scores: np.ndarray
+    bboxes: np.ndarray|None
+    landmarks: np.ndarray|None
+    scores: np.ndarray|None
+    detection: bool

--- a/l2cs/utils.py
+++ b/l2cs/utils.py
@@ -68,7 +68,6 @@ def angular(gaze, label):
 
 def select_device(device='', batch_size=None):
     # device = 'cpu' or '0' or '0,1,2,3'
-    s = f'YOLOv3 🚀 {git_describe() or date_modified()} torch {torch.__version__} '  # string
     cpu = device.lower() == 'cpu'
     if cpu:
         os.environ['CUDA_VISIBLE_DEVICES'] = '-1'  # force torch.cuda.is_available() = False
@@ -85,9 +84,8 @@ def select_device(device='', batch_size=None):
         space = ' ' * len(s)
         for i, d in enumerate(devices):
             p = torch.cuda.get_device_properties(i)
-            s += f"{'' if i == 0 else space}CUDA:{d} ({p.name}, {p.total_memory / 1024 ** 2}MB)\n"  # bytes to MB
     else:
-        s += 'CPU\n'
+        pass
 
     return torch.device('cuda:0' if cuda else 'cpu')
 
@@ -143,3 +141,8 @@ def getArch(arch,bins):
                 'The default value of ResNet50 will be used instead!')
         model = L2CS( torchvision.models.resnet.Bottleneck, [3, 4, 6,  3], bins)
     return model
+
+def stackSave(ar:list):
+    """ Wrapper for np.stack to with error handling when trying to stack empty lists. If the length of the passed list == 0, returns None else returns np.stack(ar) as expected
+    """
+    return np.stack(ar) if len(ar) > 0 else None

--- a/l2cs/vis.py
+++ b/l2cs/vis.py
@@ -33,7 +33,12 @@ def draw_bbox(frame: np.ndarray, bbox: np.ndarray):
     return frame
 
 def render(frame: np.ndarray, results: GazeResultContainer):
-
+    
+    # Check if there is a detection in the frame/results object. If not, return an image with annotation "No detection".
+    if not results.detection:
+        frame = cv2.putText(frame, "No detection", (10,40), cv2.FONT_HERSHEY_COMPLEX_SMALL, 1, (0,255,0), 2, cv2.LINE_AA)
+        return frame
+        
     # Draw bounding boxes
     for bbox in results.bboxes:
         frame = draw_bbox(frame, bbox)


### PR DESCRIPTION
Problem: when no face is detected, the program crashes. Caused by `np.stack` of an empty list.
- Added a check that there is at least one detection above the score threshold, otherwise exit with no detection
- Added `detection: bool` in `GazeResultsContainer` to save no detection
- Added `utils.saveStack` to prevent calling `np.stack` on an empty list. Returns either `np.array` or `None`
- Added feature in `vis.render` that annotates the image with `no detection` if there is no detection

Problem: when running the system on (not ideal) videos for data analysis, it can happen that more than one face is detected if there is only one person in the frame. This complicates data analysis.
- Added the option `single_face: bool = False` to `pipeline.step`. If `True`, selects the highest scoring face and discards all other detections

Problem: the usage example in `README.md` does not work
- Imported all used packages
- Added hints for torch devices (`gpu` is not a valid torch device)
- Added display of the rendered image

Problem: `demo.py` does not run
- Removed the string `s` from `utils.selected_device`, as it calls the undefined function `date_modified()`. As the string is never used (and mentions `YOLOv3`), I deemed it deprecated and removed it in total.