### PR TITLE
Fix: align pitch and yaw return order between model and pipeline

### DIFF
--- a/l2cs/model.py
+++ b/l2cs/model.py
@@ -65,8 +65,9 @@ class L2CS(nn.Module):
 
         
         # gaze
-        pre_yaw_gaze =  self.fc_yaw_gaze(x)
         pre_pitch_gaze = self.fc_pitch_gaze(x)
+        pre_yaw_gaze =  self.fc_yaw_gaze(x)
+        
         return pre_pitch_gaze, pre_yaw_gaze
 
 

--- a/l2cs/model.py
+++ b/l2cs/model.py
@@ -67,7 +67,7 @@ class L2CS(nn.Module):
         # gaze
         pre_yaw_gaze =  self.fc_yaw_gaze(x)
         pre_pitch_gaze = self.fc_pitch_gaze(x)
-        return pre_yaw_gaze, pre_pitch_gaze
+        return pre_pitch_gaze, pre_yaw_gaze
 
 
 


### PR DESCRIPTION
Fixes #45 

### Changes Made
- Standardized the return and unpacking order of `pitch` and `yaw` to be consistent between `l2cs/model.py` and `l2cs/pipeline.py`.
- Fixed gaze visualization swapping pitch and yaw incorrectly.